### PR TITLE
Fix 'context is value' bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,11 +75,10 @@ HandlebarsWriter.prototype.write = function (readTree, destDir) {
         var template = self.handlebars.compile(str);
         fs.writeFileSync(path.join(destDir, targetHTMLFile), template(output));
       }
-      if ('function' !== typeof self.context) write(self.context);
-      return Promise.resolve(self.context(targetFile)).then(write);
+      var output = ('function' !== typeof self.context) ? self.context : self.context(targetFile);
+      return Promise.resolve(output).then(write);
     }));
   });
 };
 
 module.exports = HandlebarsWriter;
-


### PR DESCRIPTION
Hi there,

This pull request fixes a crash that occurs when options.context is absent or not a function.

E.g. this config causes the following crash:

```
var htmlPages = compileHandlebars('pages', ['*.hbs'], {
    partials: 'pages/partials'
});

Crashes at:
TypeError: Property 'context' of object [object Object] is not a function
  at /vagrant/node_modules/broccoli-handlebars/index.js:79:35
  at Array.map (native)
  at /vagrant/node_modules/broccoli-handlebars/index.js:69:33
```

The crash happens because - even if options.context is not a function - it is still called as one on this line: https://github.com/moudy/broccoli-handlebars/blob/master/index.js#L79

I tested this by rerunning the code post-fix, and no crash occurs.

Cheers

Greg
