### PR TITLE
Make node version less strict (^6.9.2 -> >=6.9.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/moudy/broccoli-handlebars",
   "main": "index.js",
   "engines": {
-    "node": "^6.9.2"
+    "node": ">=6.9.2"
   },
   "scripts": {
     "pretest": "multidep test/multidep.json",


### PR DESCRIPTION
Make node version less strict.

Without this change, "yarn install" of broccoli-handlebars on node 7 is broken.
With this change, install works fine.
